### PR TITLE
feat(core): introduce typed multi-source loader, provenance, and public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,40 @@
 # confinit
 Confinit is a lightweight, typed, multi-source configuration loader with stdlib-first design, deterministic precedence, and debug-friendly provenance. It targets teams who want “dotenv + settings in one line,” zero heavy deps, and clean type-checked configs.
+
+## Module Reference
+
+- confinit (package)
+  - Public API surface aggregating the modules below. Exposes `load`, `env`, `dotenv`, `file`, error types, `SourceInfo`, `__version__`, and the `main()` CLI entry.
+
+- confinit.loader
+  - Dataclass-based loader. `load(schema, sources=None)` merges values from sources with precedence by source order and attaches a per-field provenance map as `cfg.__provenance__`.
+
+- confinit.sources
+  - Built-in sources. `env(prefix=None)` reads environment variables; `dotenv(path, prefix=None)` parses dotenv-style key/value files; `file(path)` reads top-level TOML keys using `tomllib`.
+
+- confinit.convert
+  - Internal conversion utilities. Converts raw values into annotated field types: `str`, `int`, `float`, `bool` (true/false/1/0/yes/no/on/off), `Path`, `Enum`, and `Optional[T]` via PEP 604 unions.
+
+- confinit.errors
+  - Exception hierarchy for clear diagnostics: `ConfinitError` (base), `MissingValue`, `TypeConversionError`, and `ConfSourceError`.
+
+- confinit.types
+  - Shared types. `SourceInfo(kind, layer, path, raw_value)` records provenance for each resolved field.
+
+### Typical usage
+
+```python
+from dataclasses import dataclass
+from confinit import load, env, dotenv, file
+
+@dataclass
+class Settings:
+    debug: bool = False
+    workers: int = 4
+
+cfg = load(Settings, sources=[env(prefix="APP_"), dotenv(".env"), file("config.toml")])
+print(cfg.debug, cfg.workers)
+print(cfg.__provenance__["workers"])  # -> SourceInfo(...)
+```
+
+Precedence is deterministic and source-ordered: later sources in the list do not override earlier ones; instead, the first source that provides a value for a field wins (default order: `env()`, then `dotenv()`, then `file()`, then dataclass defaults).

--- a/src/confinit/__init__.py
+++ b/src/confinit/__init__.py
@@ -1,13 +1,49 @@
+"""Confinit public API.
+
+Primary entry points
+- load: Resolve a dataclass schema from multiple sources.
+- env / dotenv / file: Built-in sources.
+- Errors and types: ConfinitError, MissingValue, TypeConversionError, ConfSourceError, SourceInfo.
+
+Runtime version
+- __version__ is detected from installed metadata; when running from source,
+  falls back to reading ``pyproject.toml``.
+"""
+
 from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError, version as _pkg_version
 from pathlib import Path
 import tomllib
 
-__all__ = ["__version__", "main", "_detect_version"]
+from .errors import ConfSourceError, ConfinitError, MissingValue, TypeConversionError
+from .types import SourceInfo
+from .sources import env, dotenv, file
+from .loader import load
+
+__all__ = [
+    "__version__",
+    "main",
+    "_detect_version",
+    # public API
+    "load",
+    "env",
+    "dotenv",
+    "file",
+    "ConfinitError",
+    "MissingValue",
+    "TypeConversionError",
+    "ConfSourceError",
+    "SourceInfo",
+]
 
 
 def _detect_version() -> str:
+    """Return the runtime package version.
+
+    Tries installed metadata first; if unavailable (running from source),
+    falls back to reading ``pyproject.toml`` at the repository root.
+    """
     try:
         return _pkg_version("confinit")
     except PackageNotFoundError:
@@ -29,4 +65,5 @@ __version__: str = _detect_version()
 
 
 def main() -> None:
-    print("Hello from confinit!")
+    """CLI entrypoint used for a quick sanity run."""
+    print("confinit: v{}".format(__version__))

--- a/src/confinit/convert.py
+++ b/src/confinit/convert.py
@@ -1,0 +1,113 @@
+"""Type conversion helpers for confinit.
+
+Responsibilities
+- Convert raw values from sources into annotated field types.
+- Support Optional[T] (PEP 604), Enum by name/value, Path, bool parsing,
+  and basic built-ins (str/int/float).
+
+Public helpers (internal API)
+- _convert_value(raw, target, field_name): perform conversion for a field.
+- issubclass_safe: safe ``issubclass`` wrapper for dynamic types.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from pathlib import Path
+from typing import Any, get_args, get_origin
+import types as _pytypes
+
+from .errors import TypeConversionError
+
+
+def _convert_value(raw: Any, target: Any, field_name: str) -> Any:
+    """Convert ``raw`` to the ``target`` annotation for a field.
+
+    Supports Optional[T] (via PEP 604 unions), Enum by name/value, Path,
+    bool parsing, and basic built-ins. Falls back to returning the raw
+    value (or its string) when conversion is not required.
+    """
+    origin = get_origin(target)
+    args = get_args(target)
+
+    if origin is __import__("typing").Union or origin is getattr(
+        _pytypes, "UnionType", None
+    ):
+        non_none = [a for a in args if a is not type(None)]  # noqa: E721
+        if len(non_none) == 1:
+            if raw in (None, ""):
+                return None
+            return _convert_value(raw, non_none[0], field_name)
+        expected = f"Union[{', '.join(getattr(a, '__name__', str(a)) for a in args)}]"
+        raise TypeConversionError(field_name, expected, raw, "unsupported union form")
+
+    if isinstance(target, type) and issubclass_safe(target, Enum):
+        return _convert_enum(raw, target, field_name)
+
+    if target in (str, Any) or target is None:
+        return raw if isinstance(raw, str) else str(raw)
+
+    if target is int:
+        try:
+            return int(raw)
+        except Exception as e:
+            raise TypeConversionError(field_name, "int", raw, str(e)) from e
+
+    if target is float:
+        try:
+            return float(raw)
+        except Exception as e:
+            raise TypeConversionError(field_name, "float", raw, str(e)) from e
+
+    if target is bool:
+        return _to_bool(raw, field_name)
+
+    if isinstance(target, type) and issubclass_safe(target, Path):
+        try:
+            return Path(raw)
+        except Exception as e:
+            raise TypeConversionError(field_name, "Path", raw, str(e)) from e
+
+    if isinstance(target, type):
+        if isinstance(raw, target):  # type: ignore[arg-type]
+            return raw
+
+    return raw
+
+
+def _to_bool(raw: Any, field_name: str) -> bool:
+    """Parse flexible booleans (true/false/1/0/yes/no/on/off)."""
+    if isinstance(raw, bool):
+        return raw
+    s = str(raw).strip().lower()
+    truthy = {"1", "true", "yes", "on"}
+    falsy = {"0", "false", "no", "off"}
+    if s in truthy:
+        return True
+    if s in falsy:
+        return False
+    raise TypeConversionError(
+        field_name, "bool", raw, "accepted: true/false/1/0/yes/no/on/off"
+    )
+
+
+def _convert_enum(raw: Any, enum_type: type[Enum], field_name: str) -> Enum:
+    """Convert by matching Enum name (case-insensitive) or value string."""
+    s = str(raw)
+    for member in enum_type:
+        if member.name.lower() == s.lower():
+            return member
+    for member in enum_type:
+        if str(member.value) == s:
+            return member
+    raise TypeConversionError(
+        field_name, enum_type.__name__, raw, "no matching enum member"
+    )
+
+
+def issubclass_safe(cls: Any, base: type) -> bool:
+    """Like ``issubclass`` but guards against non-type inputs."""
+    try:
+        return isinstance(cls, type) and issubclass(cls, base)
+    except Exception:
+        return False

--- a/src/confinit/errors.py
+++ b/src/confinit/errors.py
@@ -1,0 +1,49 @@
+"""Error types used across the confinit package.
+
+This module defines a small, explicit hierarchy of exceptions used by the
+loader and sources. Each error provides actionable context to aid debugging.
+
+Public classes
+- ConfinitError: Base class for all confinit errors.
+- MissingValue: Raised when a required field has no value in any source.
+- TypeConversionError: Raised when converting a raw value to a target type fails.
+- ConfSourceError: Raised for failures reading or parsing configuration sources.
+"""
+
+from __future__ import annotations
+
+
+class ConfinitError(Exception):
+    pass
+
+
+class MissingValue(ConfinitError):
+    def __init__(self, field: str, source_chain: list[str]) -> None:
+        msg = "Missing required value for field '{f}' (checked: {c})".format(
+            f=field, c=" > ".join(source_chain) or "defaults"
+        )
+        super().__init__(msg)
+        self.field = field
+        self.source_chain = source_chain
+
+
+class TypeConversionError(ConfinitError):
+    def __init__(self, field: str, expected: str, raw: object, reason: str) -> None:
+        msg = (
+            f"Type conversion error for field '{field}': expected {expected}, "
+            f"got {raw!r} ({reason})"
+        )
+        super().__init__(msg)
+        self.field = field
+        self.expected = expected
+        self.raw = raw
+        self.reason = reason
+
+
+class ConfSourceError(ConfinitError):
+    """Raised when a configuration source cannot be read or parsed.
+
+    Examples include unreadable .env files and TOML parse errors.
+    """
+
+    pass

--- a/src/confinit/loader.py
+++ b/src/confinit/loader.py
@@ -1,0 +1,99 @@
+"""Dataclass-based configuration loader.
+
+Key function
+- load(schema, sources=None): Resolve a dataclass ``schema`` by merging values
+  from ``sources`` (default: ``env()``, ``dotenv('.env')``, ``file('config.toml')``)
+  with precedence by source order. Attaches per-field provenance map as
+  ``instance.__provenance__`` using ``SourceInfo``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import MISSING, Field, fields, is_dataclass
+from typing import Any, Dict, Iterable, Tuple, Type, TypeVar, get_type_hints, cast
+
+from .convert import _convert_value
+from .errors import ConfinitError, MissingValue, TypeConversionError
+from .sources import dotenv, env, file
+from .types import SourceInfo
+
+Collect = Dict[str, Tuple[Any, SourceInfo]]
+T = TypeVar("T")
+
+
+def load(schema: Type[T], sources: Iterable[object] | None = None) -> T:
+    """Load a dataclass ``schema`` from multiple sources.
+
+    - Applies sources in order and takes the first value found per field.
+    - Default sources: ``env()``, ``dotenv('.env')``, ``file('config.toml')``.
+    - Performs basic type conversions (str/int/float/bool/Path/Enum/Optional).
+    - Attaches a provenance map at ``instance.__provenance__`` for debugging.
+
+    Args:
+        schema: A dataclass type defining the settings schema.
+        sources: Iterable of source objects with a ``collect(schema)`` method.
+
+    Returns:
+        An instance of ``schema`` populated from the configured sources.
+
+    Raises:
+        ConfinitError: If ``schema`` is not a dataclass or a source is invalid.
+        MissingValue: If a required field has no value in any source.
+        TypeConversionError: If converting a raw value to a target type fails.
+    """
+    if not is_dataclass(schema):
+        raise ConfinitError("load() expects a dataclass type as schema")
+    # Narrow for static analyzers: we only proceed with dataclass types
+    schema_type = cast(type[Any], schema)
+
+    srcs: list[object] = (
+        list(sources)
+        if sources is not None
+        else [env(), dotenv(".env"), file("config.toml")]
+    )
+
+    merged: Collect = {}
+    source_names: list[str] = []
+    for s in srcs:
+        if hasattr(s, "collect") and callable(getattr(s, "collect")):
+            collected = s.collect(schema_type)
+            source_names.append(type(s).__name__)
+            for k, v in collected.items():
+                if k not in merged:
+                    merged[k] = v
+        else:  # pragma: no cover
+            raise ConfinitError(f"Invalid source provided: {s!r}")
+
+    kwargs: Dict[str, Any] = {}
+    provenance: Dict[str, SourceInfo] = {}
+    type_hints = get_type_hints(schema_type, include_extras=True)
+    for f in _iter_fields(schema_type):
+        if f.name in merged:
+            raw, info = merged[f.name]
+            try:
+                target = type_hints.get(f.name, f.type)
+                kwargs[f.name] = _convert_value(raw, target, f.name)
+            except TypeConversionError:
+                provenance[f.name] = info
+                raise
+            provenance[f.name] = info
+        else:
+            if f.default is not MISSING or f.default_factory is not MISSING:  # type: ignore[attr-defined]
+                provenance[f.name] = SourceInfo(
+                    kind="default", layer=99, path=None, raw_value=f.default
+                )
+            else:
+                raise MissingValue(f.name, source_chain=source_names)
+
+    instance: T = schema(**kwargs)  # type: ignore[misc]
+    setattr(instance, "__provenance__", provenance)
+    return instance
+
+
+def _iter_fields(schema: object) -> Iterable[Field[Any]]:
+    """Iterate dataclass fields for ``schema``.
+
+    Assumes the caller has already validated that ``schema`` is a dataclass
+    type. Uses a local cast to keep static analyzers satisfied.
+    """
+    return fields(cast(Any, schema))

--- a/src/confinit/sources.py
+++ b/src/confinit/sources.py
@@ -1,0 +1,178 @@
+"""Built-in configuration sources: env vars, .env files, and TOML files.
+
+Public factory functions
+- env(prefix: str | None = None): read environment variables (uppercase names,
+  optional ``prefix`` before names).
+- dotenv(path: str, prefix: str | None = None): read key=value pairs from a
+  dotenv-like file; supports ``export``, quotes, and inline ``#`` comments.
+- file(path: str): read top-level keys from a TOML file using ``tomllib``.
+
+Each source implements a ``collect(schema) -> dict[field, (raw, SourceInfo)]``
+used by the loader to merge values and record provenance.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Dict, Tuple
+import tomllib
+
+from .errors import ConfSourceError
+from .types import SourceInfo
+
+CollectResult = Dict[str, Tuple[Any, SourceInfo]]
+
+
+def _upper_name(name: str) -> str:
+    return name.upper()
+
+
+class _EnvSource:
+    def __init__(self, prefix: str | None = None) -> None:
+        self.prefix = prefix
+
+    def collect(self, schema: type) -> CollectResult:
+        """Collect env var overrides for the given schema.
+
+        Uppercases field names and optionally prefixes them. Only variables
+        present in the environment are returned.
+        """
+        out: CollectResult = {}
+        for f in schema.__dataclass_fields__.values():  # type: ignore[attr-defined]
+            env_name = (
+                _upper_name(f.name)
+                if not self.prefix
+                else f"{self.prefix}{_upper_name(f.name)}"
+            )
+            if env_name in os.environ:
+                raw = os.environ[env_name]
+                out[f.name] = (
+                    raw,
+                    SourceInfo(kind="env", layer=10, path=env_name, raw_value=raw),
+                )
+        return out
+
+
+class _DotenvSource:
+    def __init__(self, path: str, prefix: str | None = None) -> None:
+        self.path = path
+        self.prefix = prefix
+
+    def collect(self, schema: type) -> CollectResult:
+        """Read a dotenv-like file and return matching keys for the schema.
+
+        Supports ``export`` prefix, quoted values, and inline ``#`` comments.
+        If the file does not exist, returns an empty mapping.
+        """
+        file_path = Path(self.path)
+        if not file_path.exists():
+            return {}
+        try:
+            content = file_path.read_text(encoding="utf-8")
+        except OSError as e:
+            raise ConfSourceError(f"Failed to read .env at {self.path}: {e}") from e
+        env_map = _parse_dotenv(content)
+        out: CollectResult = {}
+        for f in schema.__dataclass_fields__.values():  # type: ignore[attr-defined]
+            names: list[str] = []
+            if self.prefix:
+                names.append(f"{self.prefix}{_upper_name(f.name)}")
+            names.extend((_upper_name(f.name), f.name, f.name.lower()))
+            for n in names:
+                if n in env_map:
+                    raw = env_map[n]
+                    out[f.name] = (
+                        raw,
+                        SourceInfo(
+                            kind="dotenv",
+                            layer=20,
+                            path=f"{self.path}:{n}",
+                            raw_value=raw,
+                        ),
+                    )
+                    break
+        return out
+
+
+class _TomlFileSource:
+    def __init__(self, path: str) -> None:
+        self.path = path
+
+    def collect(self, schema: type) -> CollectResult:
+        """Read a TOML file and map top-level keys to schema fields."""
+        p = Path(self.path)
+        if not p.exists():
+            return {}
+        try:
+            data = tomllib.loads(p.read_text(encoding="utf-8"))
+        except Exception as e:  # pragma: no cover - upstream parse errors
+            raise ConfSourceError(f"Failed to parse TOML at {self.path}: {e}") from e
+        out: CollectResult = {}
+        for f in schema.__dataclass_fields__.values():  # type: ignore[attr-defined]
+            if f.name in data:
+                raw = data[f.name]
+                out[f.name] = (
+                    raw,
+                    SourceInfo(kind="file", layer=30, path=self.path, raw_value=raw),
+                )
+        return out
+
+
+def env(prefix: str | None = None) -> _EnvSource:
+    """Create an environment variable source.
+
+    Args:
+        prefix: Optional uppercase prefix like ``APP_``.
+
+    Returns:
+        An environment variable source instance.
+    """
+    return _EnvSource(prefix=prefix)
+
+
+def dotenv(path: str, prefix: str | None = None) -> _DotenvSource:
+    """Create a dotenv file source.
+
+    Args:
+        path: Path to the ``.env`` file.
+        prefix: Optional uppercase prefix to search alongside bare names.
+
+    Returns:
+        A dotenv source instance.
+    """
+    return _DotenvSource(path=path, prefix=prefix)
+
+
+def file(path: str) -> _TomlFileSource:
+    """Create a TOML file source pointing to ``path``."""
+    return _TomlFileSource(path=path)
+
+
+def _parse_dotenv(text: str) -> Dict[str, str]:
+    """Parse dotenv text into a dict of key -> string value.
+
+    Handles ``export`` prefix, simple quotes, and inline ``#`` comments.
+    Lines without ``=`` are ignored.
+    """
+    result: Dict[str, str] = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :]
+        if "#" in line:
+            before, _, _after = line.partition("#")
+            line = before.strip()
+        if "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        key = key.strip()
+        val = val.strip()
+        if (val.startswith('"') and val.endswith('"')) or (
+            val.startswith("'") and val.endswith("'")
+        ):
+            val = val[1:-1]
+        result[key] = val
+    return result

--- a/src/confinit/types.py
+++ b/src/confinit/types.py
@@ -1,0 +1,20 @@
+"""Shared simple types used by confinit.
+
+Public classes
+- SourceInfo: Records where a value came from (kind/layer/path/raw_value)
+  and is attached per-field to the resolved configuration object as
+  ``cfg.__provenance__[field]``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class SourceInfo:
+    kind: str
+    layer: int
+    path: str | None
+    raw_value: Any

--- a/tests/test_conversion_and_errors.py
+++ b/tests/test_conversion_and_errors.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+import confinit as ci
+
+
+class Color(Enum):
+    RED = "red"
+    BLUE = "blue"
+
+
+@dataclass
+class Settings:
+    debug: bool = False
+    workers: int = 4
+    rate: float = 1.5
+    data_dir: Path | None = None
+    color: Color = Color.RED
+    optional_name: str | None = None
+
+
+def test_type_conversions(monkeypatch):
+    monkeypatch.setenv("DEBUG", "true")
+    monkeypatch.setenv("WORKERS", "10")
+    monkeypatch.setenv("RATE", "2.75")
+    monkeypatch.setenv("COLOR", "BLUE")
+    monkeypatch.setenv("DATA_DIR", "/tmp/data")
+    monkeypatch.setenv("OPTIONAL_NAME", "")
+
+    cfg = ci.load(Settings, sources=[ci.env()])
+    assert cfg.debug is True
+    assert cfg.workers == 10
+    assert cfg.rate == 2.75
+    assert cfg.color is Color.BLUE
+    assert cfg.data_dir == Path("/tmp/data")
+    assert cfg.optional_name is None
+
+
+def test_bool_invalid_raises(monkeypatch):
+    @dataclass
+    class S:
+        debug: bool
+
+    monkeypatch.setenv("DEBUG", "maybe")
+    try:
+        ci.load(S, sources=[ci.env()])
+        assert False
+    except ci.TypeConversionError as e:
+        assert "bool" in str(e)
+        assert "maybe" in str(e)
+
+
+def test_enum_by_value(monkeypatch):
+    @dataclass
+    class S2:
+        color: Color
+
+    monkeypatch.setenv("COLOR", "red")
+    cfg = ci.load(S2, sources=[ci.env()])
+    assert cfg.color is Color.RED
+
+
+def test_type_errors_are_clear(monkeypatch):
+    @dataclass
+    class S:
+        count: int
+
+    monkeypatch.setenv("COUNT", "not-an-int")
+    try:
+        ci.load(S, sources=[ci.env()])
+        assert False
+    except ci.TypeConversionError as e:
+        assert "int" in str(e)
+        assert "not-an-int" in str(e)
+
+
+def test_float_conversion_error(monkeypatch):
+    @dataclass
+    class S:
+        rate: float
+
+    monkeypatch.setenv("RATE", "nope")
+    try:
+        ci.load(S, sources=[ci.env()])
+        assert False
+    except ci.TypeConversionError as e:
+        assert "float" in str(e)
+
+
+def test_path_conversion_error_from_toml(tmp_path):
+    @dataclass
+    class S:
+        p: Path
+
+    p = tmp_path / "c.toml"
+    p.write_text("p = 123\n")
+    try:
+        ci.load(S, sources=[ci.file(str(p))])
+        assert False
+    except ci.TypeConversionError as e:
+        assert "Path" in str(e)
+
+
+def test_bool_false_and_true_variants(monkeypatch):
+    @dataclass
+    class S:
+        a: bool
+        b: bool
+
+    monkeypatch.setenv("A", "off")
+    monkeypatch.setenv("B", "ON")
+    cfg = ci.load(S, sources=[ci.env()])
+    assert cfg.a is False and cfg.b is True
+
+
+def test_enum_invalid(monkeypatch):
+    @dataclass
+    class S:
+        color: Color
+
+    monkeypatch.setenv("COLOR", "green")
+    try:
+        ci.load(S, sources=[ci.env()])
+        assert False
+    except ci.TypeConversionError as e:
+        assert "no matching enum member" in str(e)
+
+
+def test_toml_parse_error(tmp_path):
+    bad = tmp_path / "bad.toml"
+    bad.write_text("[not-closed\nkey = 1")
+    try:
+        ci.load(Settings, sources=[ci.file(str(bad))])
+        assert False
+    except ci.ConfSourceError as e:
+        assert "Failed to parse TOML" in str(e)
+
+
+def test_invalid_schema_rejected():
+    try:
+        ci.load(int, sources=[])  # type: ignore[arg-type]
+        assert False
+    except ci.ConfinitError as e:
+        assert "dataclass" in str(e)
+
+
+def test_unsupported_union_form(monkeypatch):
+    @dataclass
+    class S3:
+        u: int | str
+
+    monkeypatch.setenv("U", "1")
+    try:
+        ci.load(S3, sources=[ci.env()])
+        assert False
+    except ci.TypeConversionError as e:
+        assert "Union[int, str]" in str(e)
+
+
+def test_dotenv_export_and_quotes(tmp_path):
+    envfile = tmp_path / ".env"
+    envfile.write_text('export OPTIONAL_NAME="Alice" # inline comment\n')
+    cfg = ci.load(Settings, sources=[ci.dotenv(str(envfile))])
+    assert cfg.optional_name == "Alice"
+
+
+def test_dotenv_read_error_when_directory(tmp_path):
+    d = tmp_path / ".env"
+    d.mkdir()
+    try:
+        ci.load(Settings, sources=[ci.dotenv(str(d))])
+        assert False
+    except ci.ConfSourceError as e:
+        assert ".env" in str(e)
+
+
+def test_str_coercion_from_toml_numeric(tmp_path):
+    @dataclass
+    class S:
+        name: str
+
+    p = tmp_path / "c.toml"
+    p.write_text("name = 123\n")
+    cfg = ci.load(S, sources=[ci.file(str(p))])
+    assert cfg.name == "123"
+
+
+def test_path_from_toml(tmp_path):
+    @dataclass
+    class S2:
+        data_dir: Path
+
+    p = tmp_path / "c.toml"
+    p.write_text('data_dir = "/var/lib/app"\n')
+    cfg = ci.load(S2, sources=[ci.file(str(p))])
+    assert cfg.data_dir == Path("/var/lib/app")
+
+
+def test_missing_required_field_raises():
+    @dataclass
+    class S:
+        required: int
+
+    try:
+        ci.load(S, sources=[])  # type: ignore[arg-type]
+        assert False
+    except ci.MissingValue as e:
+        assert "required" in str(e)
+
+
+def test_dict_pass_through_from_toml(tmp_path):
+    @dataclass
+    class S:
+        meta: dict
+
+    p = tmp_path / "c.toml"
+    p.write_text('meta = {k="v"}\n')
+    cfg = ci.load(S, sources=[ci.file(str(p))])
+    assert cfg.meta == {"k": "v"}
+
+
+def test_bool_from_toml_true(tmp_path):
+    @dataclass
+    class S:
+        debug: bool
+
+    p = tmp_path / "c.toml"
+    p.write_text("debug = true\n")
+    cfg = ci.load(S, sources=[ci.file(str(p))])
+    assert cfg.debug is True
+
+
+def test_dotenv_line_without_equals_ignored(tmp_path):
+    p = tmp_path / ".env"
+    p.write_text("NOEQUALS\nworkers=3\n")
+
+    @dataclass
+    class S:
+        workers: int = 1
+
+    cfg = ci.load(S, sources=[ci.dotenv(str(p))])
+    assert cfg.workers == 3

--- a/tests/test_loader_precedence.py
+++ b/tests/test_loader_precedence.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+import textwrap
+
+import confinit as ci
+
+
+class Color(Enum):
+    RED = "red"
+    BLUE = "blue"
+
+
+@dataclass
+class Settings:
+    debug: bool = False
+    workers: int = 4
+    rate: float = 1.5
+    data_dir: Path | None = None
+    color: Color = Color.RED
+    optional_name: str | None = None
+
+
+def test_file_and_defaults(tmp_path):
+    cfg_path = tmp_path / "config.toml"
+    cfg_path.write_text(
+        textwrap.dedent(
+            """
+            workers = 8
+            rate = 2.25
+            color = "blue"
+            """
+        ).strip()
+    )
+
+    cfg = ci.load(Settings, sources=[ci.file(str(cfg_path))])
+    assert cfg.debug is False
+    assert cfg.workers == 8
+    assert cfg.rate == 2.25
+    assert cfg.color is Color.BLUE
+    assert cfg.optional_name is None
+    prov = cfg.__provenance__
+    assert prov["debug"].kind == "default"
+    assert prov["workers"].kind == "file"
+
+
+def test_dotenv_overrides_file(tmp_path):
+    envfile = tmp_path / ".env"
+    envfile.write_text("WORKERS=6\n# comment\nrate=3.5\n")
+    cfg_path = tmp_path / "config.toml"
+    cfg_path.write_text("workers = 2\nrate = 1.0\n")
+
+    cfg = ci.load(Settings, sources=[ci.dotenv(str(envfile)), ci.file(str(cfg_path))])
+    assert cfg.workers == 6
+    assert cfg.rate == 3.5
+    assert cfg.__provenance__["workers"].kind == "dotenv"
+
+
+def test_env_overrides_all(monkeypatch, tmp_path):
+    envfile = tmp_path / ".env"
+    envfile.write_text("APP_WORKERS=7\n")
+    toml_path = tmp_path / "config.toml"
+    toml_path.write_text("workers = 1\n")
+
+    monkeypatch.setenv("APP_WORKERS", "9")
+    cfg = ci.load(
+        Settings,
+        sources=[
+            ci.env(prefix="APP_"),
+            ci.dotenv(str(envfile), prefix="APP_"),
+            ci.file(str(toml_path)),
+        ],
+    )
+    assert cfg.workers == 9
+    assert cfg.__provenance__["workers"].kind == "env"
+    assert cfg.__provenance__["workers"].path == "APP_WORKERS"
+
+
+def test_dotenv_missing_file_no_effect(tmp_path):
+    cfg_path = tmp_path / "config.toml"
+    cfg_path.write_text("workers = 5\n")
+    cfg = ci.load(
+        Settings, sources=[ci.dotenv(str(tmp_path / ".env")), ci.file(str(cfg_path))]
+    )
+    assert cfg.workers == 5
+
+
+def test_nonexistent_toml_uses_defaults(tmp_path):
+    cfg = ci.load(Settings, sources=[ci.file(str(tmp_path / "missing.toml"))])
+    assert cfg.workers == 4

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -58,7 +58,7 @@ def test_detect_version_default_when_no_pyproject(monkeypatch):
 def test_main_prints_greeting(capsys):
     confinit.main()
     out = capsys.readouterr().out.strip()
-    assert out == "Hello from confinit!"
+    assert out == "confinit: v{}".format(confinit.__version__)
 
 
 def test_version_matches_pyproject() -> None:


### PR DESCRIPTION
### Description

- Summary: Add a dataclass-based configuration loader with deterministic source precedence, rich type
conversions, provenance tracking, and a clean public API. Update CLI to print the installed version.
Expand README with module reference and usage.
- Motivation: Provide “dotenv + settings in one line” with stdlib-first design, predictable precedence
(CLI > ENV > .env > file > defaults when assembled), and debug-friendly provenance to trace where values
came from.
- Scope: New core modules, tests, and README docs. No external deps added.

### Key Changes

- Loader: load(schema, sources) merges sources in order; first value wins; attaches __provenance__ per
field.
- Sources: env(prefix), dotenv(path, prefix) (export, quotes, inline comments), file(path) (TOML via
tomllib).
- Conversions: str, int, float, flexible bool (true/false/1/0/yes/no/on/off), Path, Enum by name/value,
and Optional via PEP 604 unions with one non-None type.
- Errors: ConfinitError, MissingValue, TypeConversionError, ConfSourceError for clear diagnostics.
- Public API: Re-export load, env, dotenv, file, errors, SourceInfo, and __version__ from confinit.
- CLI: main() now prints confinit: v{__version__} for quick sanity checks.
- Docs: README adds Module Reference, example, and precedence notes.

### Files Touched

- README.md: +38 lines (module docs, usage, precedence)
- src/confinit/init.py: expose API, versioned CLI
- src/confinit/{convert,errors,loader,sources,types}.py: new core modules
- tests: add comprehensive tests for conversions, precedence, and versioned CLI

### Testing

- New tests:
    - Conversion and error paths, including invalid inputs.
    - Precedence across env/.env/file and defaults; provenance assertions.
    - Version detection and CLI output.
- How to run:
    - uv run pytest -q
    - Lint: uv run ruff check .
    - Types: uv run mypy src
    - Coverage: uv run pytest --cov=src/confinit --cov-report=term-missing

### Compatibility / Notes

- CLI output changed from “Hello from confinit!” to “confinit: v{version}”.
- Default precedence when not specified: env(), then dotenv('.env'), then file('config.toml'), then
dataclass defaults.